### PR TITLE
Document max_score in heuristics

### DIFF
--- a/docs/developer_manual/services/service_manifest.md
+++ b/docs/developer_manual/services/service_manifest.md
@@ -74,6 +74,7 @@ The table below shows all the elements that the manifest file can contain, inclu
 | description | Text | Yes | Detailed description of the heuristic which addresses the technique used to score. |
 | filetype | Keyword | Yes | Regex of the filetype which applies to this heuristic. |
 | heur_id | Keyword | Yes | Unique ID for identifying the heuristic. |
+| max_score | Integer | No | The maximum score the heuristic can have. |
 | name | Keyword | Yes | Short name for the heuristic. |
 | score | Integer | Yes | Score that should be applied when this heuristic is set. |
 


### PR DESCRIPTION
Discovered this, didn't seem to find it in the docs.

Example: Technically VT should've scored this at 11K, but I capped the heuristic to 1K using max_score
![image](https://user-images.githubusercontent.com/62077998/100750017-7335cb80-33b3-11eb-8db2-f4d4a850b1a1.png)
