### PR TITLE
Remove not existing config

### DIFF
--- a/docs/installation/configuration/services.md
+++ b/docs/installation/configuration/services.md
@@ -32,9 +32,6 @@ Since this section is quite simple, we will list the default configuration at th
       # while loaded from updater or scaler
       image_variables: {}
 
-      # Minimum amount of service that will be loaded for each service
-      min_service_workers: 0
-
       # Type of services the updater will be looking for when looking for service update
       # (dev or stable)
       preferred_update_channel: stable


### PR DESCRIPTION
The "min_service_workers" config doesn't exist
in the Service config section.

To compare: https://github.com/CybercentreCanada/assemblyline-base/blob/75e0be2233ac0f29e479e3809d1770302dca5741/assemblyline/odm/models/config.py#L797