### PR TITLE
Updated scaler configuration docs

### DIFF
--- a/docs/installation/configuration/core.md
+++ b/docs/installation/configuration/core.md
@@ -74,6 +74,10 @@ The core components configuration section (`core:`) of the configuration file co
           host: 127.0.0.1
           port: 6380
       scaler:
+        additional_labels: null
+        cpu_overallocation: 1
+        memory_overallocation: 1
+        overallocation_node_limit: null
         service_defaults:
           backlog: 100
           environment:
@@ -336,6 +340,15 @@ Here is an example configuration block with inline comments about the purpose of
     ```yaml
     core:
         scaler:
+          # Percentage of CPU overallocation, represented as 0-1 float
+          cpu_overallocation: 0.5
+          # Percentage of RAM overallocation, represented as 0-1 float
+          memory_overallocation: 1
+          # If the system has this many nodes or more overallocation is ignored
+          overallocation_node_limit: 3
+          # Additional labels to be applied to services('=' delimited)
+          additional_labels:
+            - env=production
           service_defaults:
             # How many files in a service queue are considered a backlog.
             #  This weights how important scaling up a service is relative


### PR DESCRIPTION
Config docs for scaler updated with missed keys

Config source:
https://github.com/CybercentreCanada/assemblyline-base/blob/75e0be2233ac0f29e479e3809d1770302dca5741/assemblyline/odm/models/config.py#L563-L589