### PR TITLE
Change repo to display

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -207,7 +207,7 @@ plugins:
         Integration: Intégration
         Overview: Aperçu
         User's manual: Manuel d'utilisateur
-repo_url: https://github.com/CybercentreCanada/assemblyline4_docs
+repo_url: https://github.com/CybercentreCanada/assemblyline
 site_name: Assemblyline 4
 site_url: https://cybercentrecanada.github.io/assemblyline4_docs/
 theme:


### PR DESCRIPTION
GitHub link looks like this now 
![image](https://github.com/CybercentreCanada/assemblyline4_docs/assets/59843993/d0bfc539-ea79-49c3-8fe4-292c6ada3fb2)
