### PR TITLE
Updated naming convention regarding result_sample.py in service development

### DIFF
--- a/docs/developer_manual/services/run_your_service.md
+++ b/docs/developer_manual/services/run_your_service.md
@@ -32,7 +32,7 @@ cd ~/git/services/assemblyline-service-sample
 From a terminal, run the `run_service_once` module, specifying the service path for the service to run and the path to the file to scan. For this example, we will have the service scan itself.
 
 ```shell
-python -m assemblyline_v4_service.dev.run_service_once sample.Sample sample.py
+python -m assemblyline_v4_service.dev.run_service_once result_sample.Sample result_sample.py
 ```
 
 The `run_service_once` module creates a directory at the same spot where the file is found with the service name that scanned the file appended to it. In the previous example, the output of the service should be located at `~/git/services/assemblyline-service-sample/sample.py_sample`. The directory will contain a `result.json` file containing the result from the service.
@@ -40,7 +40,7 @@ The `run_service_once` module creates a directory at the same spot where the fil
 You can view the `result.json` file using the following command:
 
 ```shell
-cat ~/git/services/assemblyline-service-sample/sample.py_sample/result.json | json_pp
+cat ~/git/services/assemblyline-service-sample/result_sample.py_sample/result.json | json_pp
 ```
 
 It will look something like this:
@@ -138,7 +138,7 @@ source ~/git/services/venv/bin/activate
 cd ~/git/services/assemblyline-service-sample
 
 # Run your service
-SERVICE_PATH=sample.Sample python -m assemblyline_v4_service.run_service
+SERVICE_PATH=result_sample.Sample python -m assemblyline_v4_service.run_service
 ```
 
 ## Production container mode


### PR DESCRIPTION
# Reason for pull request:

Within the docs for creating a new service there is reference to `result_sample.py`:

> Service Python code
> In your service directory, you will first start by creating your service's python file. Let's use `result_sample.py`.
> Put the following code in your service's file:

[Build your first service](https://cybercentrecanada.github.io/assemblyline4_docs/developer_manual/services/developing_an_assemblyline_service/#build-your-first-service)

Afterwards, this same file is referenced as `sample.py` in the section on how to run your service:

> From a terminal, `run the run_service_once` module, specifying the service path for the service to run and the path to the file to scan. For this example, we will have the service scan itself.
> 
> `python -m assemblyline_v4_service.dev.run_service_once sample.Sample sample.py\`
> 
> The `run_service_once` module creates a directory at the same spot where the file is found with the service name that scanned the file appended to it. In the previous example, the output of the service should be located at `~/git/services/assemblyline-service-sample/sample.py_sample`. The directory will contain a `result.json` file containing the result from the service.

[Run your service](https://cybercentrecanada.github.io/assemblyline4_docs/developer_manual/services/run_your_service/#standalone-mode

When following the exact commands offered within the step-by-step, the execution will fail as there is no `sample.py` for this newly created service:

```
(venv) user@assemblyline:~/deployments/services/assemblyline-service-sample$ python -m assemblyline_v4_service.dev.run_service_once sample.Sample sample.py
Could not find service in path. Check your environment variables.
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/user/deployments/alv4/assemblyline-v4-service/assemblyline_v4_service/dev/run_service_once.py", line 250, in <module>
    rs.try_run()
  File "/home/user/deployments/alv4/assemblyline-v4-service/assemblyline_v4_service/dev/run_service_once.py", line 35, in try_run
    self.service_class = load_module_by_path(SERVICE_PATH)
  File "/home/user/deployments/alv4/assemblyline-base/assemblyline/common/importing.py", line 12, in load_module_by_path
    module = importlib.import_module(module_path)
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'sample'
```
# Suggestion
I would like to suggest to adopt either the use of `sample.py` throughout the services example, or stick with `result_sample.py` as is proposed through this PR.

