### PR TITLE
Corrected MetaDefender Sandbox name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repository contains the source for Assemblyline's documentation hosted at t
 
 ## Contribute 
 
-To contribute to the documentation, you can either edit the .md files inline right from github or run it yourself locally using the instruction located [here](https://cybercentrecanada.github.io/assemblyline4_docs/en/developer_manual/docs/docs/).
+To contribute to the documentation, you can either edit the .md files inline right from github or run it yourself locally using the instruction located [here](https://cybercentrecanada.github.io/assemblyline4_docs/developer_manual/docs/docs/).

--- a/docs/overview/community_services.fr.md
+++ b/docs/overview/community_services.fr.md
@@ -15,7 +15,7 @@ Cette page contient la liste de services crée et partagé avec le publique.
 | ClamAV | Assemblyline service which submits a file to ClamAV and displays the result | [NVISO](https://github.com/NVISOsecurity) | [link](https://github.com/NVISOsecurity/assemblyline-service-clamav) |
 | MalwareBazaar | Assemblyline service fetching Malware Bazaar report | [NVISO](https://github.com/NVISOsecurity) | [link](https://github.com/NVISOsecurity/assemblyline-service-malware-bazaar) |
 | MsgParser | Simple MSG extractor AssemblyLine service | [NVISO](https://github.com/NVISOsecurity) | [link](https://github.com/NVISOsecurity/assemblyline-service-msg-extractor) |
-| OPSWAT Filescan Sandbox :material-new-box:{ .big_icon } | Submits a file or a URL to OPSWAT Filescan Sandbox | [OPSWAT](https://github.com/OPSWAT/) | [link](https://github.com/OPSWAT/assemblyline-service-opswat-filescan-sandbox) |
+| MetaDefender Sandbox :material-new-box:{ .big_icon } | Submits a file or a URL to MetaDefender Sandbox | [OPSWAT](https://github.com/OPSWAT/) | [link](https://github.com/OPSWAT/assemblyline-service-metadefender-sandbox) |
 | PythonExeUnpack | Python exe unpacker service | [NVISO](https://github.com/NVISOsecurity) | [link](https://github.com/NVISOsecurity/assemblyline-service-python-exe-unpacker) |
 | StegFinder | AssemblyLine service which scans for embedded data in image using StegExpose | [NVISO](https://github.com/NVISOsecurity) | [link](https://github.com/NVISOsecurity/assemblyline-service-steg-finder) |
 | Unfurl | Assemblyline service parsing a submitted URL to unshorten it. | [NVISO](https://github.com/NVISOsecurity) | [link](https://github.com/NVISOsecurity/assemblyline-service-unfurl) |

--- a/docs/overview/community_services.md
+++ b/docs/overview/community_services.md
@@ -15,7 +15,7 @@ This page lists all the services that our members have created and shared with t
 | ClamAV | Assemblyline service which submits a file to ClamAV and displays the result | [NVISO](https://github.com/NVISOsecurity) | [link](https://github.com/NVISOsecurity/assemblyline-service-clamav) |
 | MalwareBazaar | Assemblyline service fetching Malware Bazaar report | [NVISO](https://github.com/NVISOsecurity) | [link](https://github.com/NVISOsecurity/assemblyline-service-malware-bazaar) |
 | MsgParser | Simple MSG extractor AssemblyLine service | [NVISO](https://github.com/NVISOsecurity) | [link](https://github.com/NVISOsecurity/assemblyline-service-msg-extractor) |
-| OPSWAT Filescan Sandbox :material-new-box:{ .big_icon } | Submits a file or a URL to OPSWAT Filescan Sandbox | [OPSWAT](https://github.com/OPSWAT/) | [link](https://github.com/OPSWAT/assemblyline-service-opswat-filescan-sandbox) |
+| MetaDefender Sandbox :material-new-box:{ .big_icon } | Submits a file or a URL to MetaDefender Sandbox | [OPSWAT](https://github.com/OPSWAT/) | [link](https://github.com/OPSWAT/assemblyline-service-metadefender-sandbox) |
 | PythonExeUnpack | Python exe unpacker service | [NVISO](https://github.com/NVISOsecurity) | [link](https://github.com/NVISOsecurity/assemblyline-service-python-exe-unpacker) |
 | StegFinder | AssemblyLine service which scans for embedded data in image using StegExpose | [NVISO](https://github.com/NVISOsecurity) | [link](https://github.com/NVISOsecurity/assemblyline-service-steg-finder) |
 | Unfurl | Assemblyline service parsing a submitted URL to unshorten it. | [NVISO](https://github.com/NVISOsecurity) | [link](https://github.com/NVISOsecurity/assemblyline-service-unfurl) |


### PR DESCRIPTION
- corrected MetaDefender Sandbox name: After renaming in January 2024, the new name of OPSWAT Filescan Sandbox is MetaDefender Sandbox
- corrected README.md link: old link drops 404 