### PR TITLE
Remove Unnecissary/Redundant Package Installs

### DIFF
--- a/docs/installation/appliance/docker.md
+++ b/docs/installation/appliance/docker.md
@@ -22,7 +22,6 @@ This is the documentation for an appliance instance of the Assemblyline platform
         Install Docker:
         ```bash
         sudo apt-get update -y
-        sudo apt-get install -y apt-transport-https ca-certificates curl gnupg software-properties-common
         sudo install -m 0755 -d /etc/apt/keyrings
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
         sudo chmod a+r /etc/apt/keyrings/docker.gpg

--- a/docs/installation/appliance/docker.md
+++ b/docs/installation/appliance/docker.md
@@ -21,7 +21,6 @@ This is the documentation for an appliance instance of the Assemblyline platform
     === "Ubuntu"
         Install Docker:
         ```bash
-        sudo apt-get update -y
         sudo install -m 0755 -d /etc/apt/keyrings
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
         sudo chmod a+r /etc/apt/keyrings/docker.gpg


### PR DESCRIPTION
None of these packages need to be explicitly installed in any of the Ubuntu versions that these instructions assume: 20.04, 22.04.

`apt-transport-https` is a transitional package that has not been needed since Ubuntu 17 when https became the default for `apt`.

Here is `apt-cache policy` output from 20.04:

```bash
# apt-cache policy apt-transport-https ca-certificates curl gnupg software-properties-common
apt-transport-https:
  Installed: 2.0.10
  Candidate: 2.0.10
  Version table:
 *** 2.0.10 500
        500 http://mirrors.digitalocean.com/ubuntu focal-updates/universe amd64 Packages
        100 /var/lib/dpkg/status
     2.0.2ubuntu0.2 500
        500 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages
     2.0.2 500
        500 http://mirrors.digitalocean.com/ubuntu focal/universe amd64 Packages
ca-certificates:
  Installed: 20240203~20.04.1
  Candidate: 20240203~20.04.1
  Version table:
 *** 20240203~20.04.1 500
        500 http://mirrors.digitalocean.com/ubuntu focal-updates/main amd64 Packages
        500 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages
        100 /var/lib/dpkg/status
     20190110ubuntu1 500
        500 http://mirrors.digitalocean.com/ubuntu focal/main amd64 Packages
curl:
  Installed: 7.68.0-1ubuntu2.25
  Candidate: 7.68.0-1ubuntu2.25
  Version table:
 *** 7.68.0-1ubuntu2.25 500
        500 http://mirrors.digitalocean.com/ubuntu focal-updates/main amd64 Packages
        500 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages
        100 /var/lib/dpkg/status
     7.68.0-1ubuntu2 500
        500 http://mirrors.digitalocean.com/ubuntu focal/main amd64 Packages
gnupg:
  Installed: 2.2.19-3ubuntu2.2
  Candidate: 2.2.19-3ubuntu2.2
  Version table:
 *** 2.2.19-3ubuntu2.2 500
        500 http://mirrors.digitalocean.com/ubuntu focal-updates/main amd64 Packages
        500 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages
        100 /var/lib/dpkg/status
     2.2.19-3ubuntu2 500
        500 http://mirrors.digitalocean.com/ubuntu focal/main amd64 Packages
software-properties-common:
  Installed: 0.99.9.12
  Candidate: 0.99.9.12
  Version table:
 *** 0.99.9.12 500
        500 http://mirrors.digitalocean.com/ubuntu focal-updates/main amd64 Packages
        100 /var/lib/dpkg/status
     0.98.9.2 500
        500 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages
     0.98.9 500
        500 http://mirrors.digitalocean.com/ubuntu focal/main amd64 Packages
```