### PR TITLE
Check If Keyrings Directory Exists

### DIFF
--- a/docs/installation/appliance/docker.md
+++ b/docs/installation/appliance/docker.md
@@ -23,7 +23,10 @@ This is the documentation for an appliance instance of the Assemblyline platform
         ```bash
         sudo apt-get update -y
         sudo apt-get install -y apt-transport-https ca-certificates curl gnupg software-properties-common
-        sudo install -m 0755 -d /etc/apt/keyrings
+        kr="/etc/apt/keyrings"
+        if [ ! -e "$kr" ]; then
+            sudo install -m 0755 -d $kr
+        fi
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
         sudo chmod a+r /etc/apt/keyrings/docker.gpg
         echo \

--- a/docs/installation/appliance/docker.md
+++ b/docs/installation/appliance/docker.md
@@ -25,6 +25,7 @@ This is the documentation for an appliance instance of the Assemblyline platform
         sudo apt-get install -y apt-transport-https ca-certificates curl gnupg software-properties-common
         kr="/etc/apt/keyrings"
         if [ ! -e "$kr" ]; then
+            # Keyring directory creation is only required for Ubuntu 20.04 (EOL is April 2025)
             sudo install -m 0755 -d $kr
         fi
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg


### PR DESCRIPTION
All new versions of Ubuntu have the `/etc/apt/keyrings` directory by default now except for 20.04. Therefore, check if it exists before running `install`. The EOL date for 20.04 is April 2025. These lines can be removed completely at that date.