### PR TITLE
Change Version Codename Variable Subshell to "Ubuntu-y" Syntax

### DIFF
--- a/docs/installation/appliance/docker.md
+++ b/docs/installation/appliance/docker.md
@@ -28,7 +28,7 @@ This is the documentation for an appliance instance of the Assemblyline platform
         sudo chmod a+r /etc/apt/keyrings/docker.gpg
         echo \
         "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-        "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+        "$(lsb_release -cs)" stable" | \
         sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
         sudo apt-get update -y
         sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin


### PR DESCRIPTION
This is the syntax used in Ubuntu's own documentation and examples.