### PR TITLE
Fix Deprecated Command and Unnecessary Addons

### DIFF
--- a/docs/installation/appliance/kubernetes-microk8s.md
+++ b/docs/installation/appliance/kubernetes-microk8s.md
@@ -19,7 +19,9 @@ This is the documentation for an appliance instance of the Assemblyline platform
     ```
     2. Install microk8s addons:
     ```bash
-    sudo microk8s enable dns ingress ha-cluster storage metrics-server
+    for addon in "ingress" "hostpath-storage" "metrics-server"; do
+        sudo microk8s enable "$addon"
+    done
     ```
     3. Install Helm and set it up to use with microk8s:
     ```bash


### PR DESCRIPTION
First, separate commands:

```bash
WARNING: Do not enable or disable multiple addons in one command.
         This form of chained operations on addons will be DEPRECATED in the future.
         Please, enable one addon at a time: 'microk8s enable <addon>'
```

Second, remove `dns`: it's already enabled:

```bash
Addon core/dns is already enabled
```

Third, `storage` deprecated in favor of `hostpath-storage`

```bash
DEPRECATION WARNING: 'storage' is deprecated and will soon be removed. Please use 'hostpath-storage' instead.
```