### PR TITLE
Git is default in Ubuntu 20.04+

### DIFF
--- a/docs/installation/appliance/kubernetes-microk8s.md
+++ b/docs/installation/appliance/kubernetes-microk8s.md
@@ -27,10 +27,6 @@ This is the documentation for an appliance instance of the Assemblyline platform
     sudo mkdir /var/snap/microk8s/current/bin
     sudo ln -s /snap/bin/helm /var/snap/microk8s/current/bin/helm
     ```
-    4. Install git:
-    ```bash
-    sudo apt install git
-    ```
 === "Offline"
 
     1. Download offline packages (On an internet-connected system):


### PR DESCRIPTION
```bash
root@ubuntu-s-2vcpu-4gb-amd-nyc1-01:~# lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.4 LTS
Release:	20.04
Codename:	focal
root@ubuntu-s-2vcpu-4gb-amd-nyc1-01:~# whereis git
git: /usr/bin/git /usr/share/man/man1/git.1.gz
```